### PR TITLE
Vungle: Remove Helium reward from partner API

### DIFF
--- a/VungleAdapter/src/main/java/com/chartboost/helium/vungleadapter/VungleAdapter.kt
+++ b/VungleAdapter/src/main/java/com/chartboost/helium/vungleadapter/VungleAdapter.kt
@@ -667,7 +667,7 @@ class VungleAdapter : PartnerAdapter {
 
                         override fun onAdRewarded(id: String) {
                             PartnerLogController.log(DID_REWARD)
-                            listener?.onPartnerAdRewarded(partnerAd, Reward(0, ""))
+                            listener?.onPartnerAdRewarded(partnerAd)
                                 ?: PartnerLogController.log(
                                     CUSTOM,
                                     "Unable to fire onAdRewarded for Vungle adapter. Listener is null."


### PR DESCRIPTION
Don't merge yet. Depends upon Bichen's upcoming Helium PR.