### PR TITLE
HB-6862: Vungle 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.7.1.0.0
+- This version of the adapter has been certified with Vungle SDK 7.1.0.
+
 ### 4.7.0.0.0
 - This version of the adapter has been certified with Vungle SDK 7.0.0.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Vungle adapter mediates Vungle via the Chartboost Media
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-vungle:4.7.0.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-vungle:4.7.1.0.0"
 ```
 
 ## Contributions

--- a/VungleAdapter/build.gradle.kts
+++ b/VungleAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.7.0.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.7.1.0.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_VUNGLE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")
@@ -72,7 +72,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     // Partner SDK
-    implementation("com.vungle:vungle-ads:7.0.0")
+    implementation("com.vungle:vungle-ads:7.1.0")
 
     // Adapter Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/VungleAdapter/src/main/java/com/chartboost/mediation/vungleadapter/VungleAdapter.kt
+++ b/VungleAdapter/src/main/java/com/chartboost/mediation/vungleadapter/VungleAdapter.kt
@@ -33,7 +33,7 @@ import com.vungle.ads.VungleError.Companion.NETWORK_UNREACHABLE
 import com.vungle.ads.VungleError.Companion.NO_SERVE
 import com.vungle.ads.VungleError.Companion.PLACEMENT_NOT_FOUND
 import com.vungle.ads.VungleError.Companion.SERVER_RETRY_ERROR
-import com.vungle.ads.VungleError.Companion.VUNGLE_NOT_INITIALIZED
+import com.vungle.ads.VungleError.Companion.SDK_NOT_INITIALIZED
 import com.vungle.ads.VunglePrivacySettings
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -775,7 +775,7 @@ class VungleAdapter : PartnerAdapter {
             NO_SERVE, AD_FAILED_TO_DOWNLOAD -> ChartboostMediationError.CM_LOAD_FAILURE_NO_FILL
             SERVER_RETRY_ERROR, ASSET_DOWNLOAD_ERROR -> ChartboostMediationError.CM_AD_SERVER_ERROR
             NETWORK_ERROR, NETWORK_UNREACHABLE -> ChartboostMediationError.CM_NO_CONNECTIVITY
-            VUNGLE_NOT_INITIALIZED -> ChartboostMediationError.CM_INITIALIZATION_FAILURE_UNKNOWN
+            SDK_NOT_INITIALIZED -> ChartboostMediationError.CM_INITIALIZATION_FAILURE_UNKNOWN
             INVALID_APP_ID -> ChartboostMediationError.CM_INITIALIZATION_FAILURE_INVALID_CREDENTIALS
             PLACEMENT_NOT_FOUND -> ChartboostMediationError.CM_LOAD_FAILURE_INVALID_PARTNER_PLACEMENT
             else -> ChartboostMediationError.CM_PARTNER_ERROR


### PR DESCRIPTION
- Updated Vungle SDK version to 7.1.0.
- Updated Vungle Adapter to use `SDK_NOT_INITIALIZED` instead of `VUNGLE_NOT_INITIALIZED`.  They removed `VUNGLE_NOT_INITIALIZED`.
- Updated Changelog, README, build script to 4.7.1.0.0