### PR TITLE
fix(VungleAdapter): replace removed VungleWrapperFramework enum with string literal

### DIFF
--- a/VungleAdapter/src/main/java/com/chartboost/mediation/vungleadapter/VungleAdapter.kt
+++ b/VungleAdapter/src/main/java/com/chartboost/mediation/vungleadapter/VungleAdapter.kt
@@ -141,7 +141,7 @@ class VungleAdapter : PartnerAdapter {
                         object : InitializationListener {
                             override fun onSuccess() {
                                 VungleAds.setIntegrationName(
-                                    VungleWrapperFramework.vunglehbs,
+                                    "vunglehbs",
                                     adapterVersion,
                                 )
 


### PR DESCRIPTION
Vungle SDK 7.7.2 removed the `VungleWrapperFramework` enum class and changed the `VungleAds.setIntegrationName()` signature from `(VungleWrapperFramework, String)` to `(String, String)`. This broke compilation of the adapter, which was passing `VungleWrapperFramework.vunglehbs` as the first argument.

The fix replaces the enum reference with the string literal `"vunglehbs"`.

## Why `"vunglehbs"` is the correct value

The `VungleWrapperFramework` enum (introduced in SDK 7.5.0) was a plain Kotlin `Enum<>` with no custom properties. Each constant's `.name` property — which is what Vungle's internal `VungleInitializer` extracted from it — is its exact string representation. Bytecode decompilation of `VungleWrapperFramework.class` from SDK 7.5.0 confirms the static initializer constructs the `vunglehbs` constant with the string `"vunglehbs"`:

    ldc #112  // String vunglehbs
    invokespecial "<init>":(Ljava/lang/String;I)V
    putstatic vunglehbs

In SDK 7.7.2, `VungleAds$Companion.setIntegrationName` now takes the string directly:

    public final void setIntegrationName(java.lang.String, java.lang.String)
    // parameter names from Kotlin metadata: integrationName, version

The parameter was renamed from `wrapperFramework` to `integrationName`, confirming Vungle simply replaced the type-safe enum with a free-form string while keeping the same underlying values.

## Official references

The Vungle SDK changelog (VungleAds-SDK/CHANGELOG-Android.md) notes:
- 7.5.0: "Replace class VungleAds.WrapperFramework with VungleWrapperFramework"
- 7.7.2: "setIntegrationName() Improvements"

`setIntegrationName` is an internal/partner-facing API with no published Javadoc — the changelog entries and bytecode analysis above are the authoritative sources for this change.